### PR TITLE
Fix togglePaymentMethodStatus methodId handling

### DIFF
--- a/src/actions/util/payment-methods-unified.ts
+++ b/src/actions/util/payment-methods-unified.ts
@@ -235,7 +235,7 @@ export async function togglePaymentMethodStatus(
     const orgMethod = await prisma.organizationPaymentMethod.findFirst({
       where: {
         organizationId,
-        methodId: Number(methodId),
+        methodId,
       },
     });
 


### PR DESCRIPTION
## Summary
- keep methodId as string when toggling payment method

## Testing
- `pnpm exec vitest run src/actions/util/test/payment-methods-unified.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68434914c6b483249e124f77af8bc7ca